### PR TITLE
chore: update copyright notice to 2022

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+if has nix; then
+  use nix
+fi
+
+# cucu uses the environment variable BROWSER to pick which browser to use
+unset BROWSER

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.sass-cache
 *.iml
 
+
 # OS or Editor folders
 .DS_Store
 .cache
@@ -25,6 +26,8 @@ intermediate
 publish
 target
 .idea
+.direnv
+.env
 out
 
 # markdown previews

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/add_delete_users.rb
+++ b/examples/add_delete_users.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/change_credentials_email_address_for_users.rb
+++ b/examples/change_credentials_email_address_for_users.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/convert_look_to_lookless_tile.rb
+++ b/examples/convert_look_to_lookless_tile.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ sdk = LookerSDK::Client.new(
   :client_id => ENV['KEY'],
   :client_secret => ENV['SECRET'],
 
-  # API 3.1 URL would look like: https://myhost.com:19999/api/3.1
+  # API 4.0 URL would look like: https://myhost.com:19999/api/4.0
   :api_endpoint => ENV['URL']
 )
 #Set the dashboard here.

--- a/examples/create_credentials_email_for_users.rb
+++ b/examples/create_credentials_email_for_users.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/delete_all_user_sessions.rb
+++ b/examples/delete_all_user_sessions.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/delete_credentials_google_for_users.rb
+++ b/examples/delete_credentials_google_for_users.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/generate_password_reset_tokens_for_users.rb
+++ b/examples/generate_password_reset_tokens_for_users.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/ldap_roles_test.rb
+++ b/examples/ldap_roles_test.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/me.rb
+++ b/examples/me.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/refresh_user_notification_addresses.rb
+++ b/examples/refresh_user_notification_addresses.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/roles_and_users_with_permission.rb
+++ b/examples/roles_and_users_with_permission.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/sdk_setup.rb
+++ b/examples/sdk_setup.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,10 +36,10 @@ def sdk
 
     # use my local looker with self-signed cert
     :connection_options => {:ssl => {:verify => false}},
-    :api_endpoint => "https://localhost:19999/api/3.0",
+    :api_endpoint => "https://localhost:20000/api/4.0",
 
     # use a real looker the way you are supposed to!
     # :connection_options => {:ssl => {:verify => true}},
-    # :api_endpoint => "https://mycoolcompany.looker.com:19999/api/3.0",
+    # :api_endpoint => "https://mycoolcompany.looker.com:19999/api/4.0",
   )
 end

--- a/examples/sdk_setup.rb
+++ b/examples/sdk_setup.rb
@@ -36,7 +36,7 @@ def sdk
 
     # use my local looker with self-signed cert
     :connection_options => {:ssl => {:verify => false}},
-    :api_endpoint => "https://localhost:20000/api/4.0",
+    :api_endpoint => "https://localhost:19999/api/4.0",
 
     # use a real looker the way you are supposed to!
     # :connection_options => {:ssl => {:verify => true}},

--- a/examples/streaming_downloads.rb
+++ b/examples/streaming_downloads.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/users_with_credentials_email.rb
+++ b/examples/users_with_credentials_email.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/users_with_credentials_embed.rb
+++ b/examples/users_with_credentials_embed.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/users_with_credentials_google.rb
+++ b/examples/users_with_credentials_google.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/examples/users_with_credentials_google_without_credentials_email.rb
+++ b/examples/users_with_credentials_google_without_credentials_email.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk.rb
+++ b/lib/looker-sdk.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/authentication.rb
+++ b/lib/looker-sdk/authentication.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/configurable.rb
+++ b/lib/looker-sdk/configurable.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/default.rb
+++ b/lib/looker-sdk/default.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/error.rb
+++ b/lib/looker-sdk/error.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/rate_limit.rb
+++ b/lib/looker-sdk/rate_limit.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/response/raise_error.rb
+++ b/lib/looker-sdk/response/raise_error.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/sawyer_patch.rb
+++ b/lib/looker-sdk/sawyer_patch.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/looker-sdk/version.rb
+++ b/lib/looker-sdk/version.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,38 @@
+let
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixpkgs-21.05";
+    url =
+      "https://github.com/nixos/nixpkgs/archive/f7574a5c8fefd86b50def1827eadb9b8cb266ffd.tar.gz";
+    sha256 = "0pksag38bjdqwvmcxgyc5a31hfz1z201za21v3hb7mqd9b99lnr3";
+  }) { };
+in
+with nixpkgs;
+with stdenv;
+with lib;
+let ruby' = ruby_2_6.withPackages(ps: with ps; [bundler rake]);
+in
+mkShell {
+  name = "cucu-shell";
+  buildInputs = [ ruby' lzma zlib libxml2 ];
+
+  # Looker expects this as the default encoding otherwise does not start
+  LANG = "en_US.UTF-8";
+
+  # https://nixos.org/nixpkgs/manual/#locales
+  LOCALE_ARCHIVE =
+      optionalString isLinux "${glibcLocales}/lib/locale/locale-archive";
+
+  shellHook = ''
+      # FIXME: SSH or tooling that requires libnss-cache (https://github.com/google/libnss-cache)
+      # seems to fail since the library is not present. When I have a better understanding of Nix
+      # let's fix this.
+      # https://github.com/NixOS/nixpkgs/issues/64665#issuecomment-511411309
+      [[ ! -f /lib/x86_64-linux-gnu/libnss_cache.so.2 ]] || export LD_PRELOAD=/lib/x86_64-linux-gnu/libnss_cache.so.2:$LD_PRELOAD
+
+      export GEM_USER_DIR=$(pwd)/.gem
+      export GEM_DEFAULT_DIR=$(${ruby'}/bin/ruby -e 'puts Gem.default_dir')
+      export GEM_PATH=$GEM_DEFAULT_DIR:$GEM_PATH
+      export GEM_HOME=$GEM_USER_DIR
+      export PATH=$GEM_HOME/bin:$PATH
+     '';
+}

--- a/shell/shell.rb
+++ b/shell/shell.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -40,11 +40,11 @@ def sdk
     # Support self-signed cert *and* set longer timeout to allow for long running queries.
     :connection_options => {:ssl => {:verify => false}, :request => {:timeout => 60 * 60, :open_timeout => 30}},
 
-    :api_endpoint => "https://localhost:19999/api/3.0",
+    :api_endpoint => "https://localhost:20000/api/4.0",
 
     # Customize to use your specific looker instance
     # :connection_options => {:ssl => {:verify => true}},
-    # :api_endpoint => "https://looker.mycoolcompany.com:19999/api/3.0",
+    # :api_endpoint => "https://looker.mycoolcompany.com:19999/api/4.0",
   )
 end
 

--- a/shell/shell.rb
+++ b/shell/shell.rb
@@ -40,7 +40,7 @@ def sdk
     # Support self-signed cert *and* set longer timeout to allow for long running queries.
     :connection_options => {:ssl => {:verify => false}, :request => {:timeout => 60 * 60, :open_timeout => 30}},
 
-    :api_endpoint => "https://localhost:20000/api/4.0",
+    :api_endpoint => "https://localhost:19999/api/4.0",
 
     # Customize to use your specific looker instance
     # :connection_options => {:ssl => {:verify => true}},

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -61,7 +61,7 @@ end
 def setup_sdk
   LookerSDK.reset!
 
-  base_url = ENV['LOOKERSDK_BASE_URL'] || 'https://localhost:20000'
+  base_url = ENV['LOOKERSDK_BASE_URL'] || 'https://localhost:19999'
   verify_ssl = case ENV['LOOKERSDK_VERIFY_SSL']
                when /false/i
                  false

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -30,7 +30,7 @@ describe LookerSDK::Client do
    setup_sdk
   end
 
-  base_url = ENV['LOOKERSDK_BASE_URL'] || 'https://localhost:20000'
+  base_url = ENV['LOOKERSDK_BASE_URL'] || 'https://localhost:19999'
   verify_ssl = case ENV['LOOKERSDK_VERIFY_SSL']
                when /false/i
                  false

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -60,7 +60,7 @@ class LookerDynamicClientTest < MiniTest::Spec
     req = Rack::Request.new(env)
     req_body = req.body.gets || ''
 
-    req.base_url.must_equal 'https://localhost:20000'
+    req.base_url.must_equal 'https://localhost:19999'
     req.request_method.must_equal method.to_s.upcase
     req.path_info.must_equal path
 

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -60,7 +60,7 @@ class LookerDynamicClientTest < MiniTest::Spec
     req = Rack::Request.new(env)
     req_body = req.body.gets || ''
 
-    req.base_url.must_equal 'https://localhost:19999'
+    req.base_url.must_equal 'https://localhost:20000'
     req.request_method.must_equal method.to_s.upcase
     req.path_info.must_equal path
 

--- a/test/looker/test_dynamic_client_agent.rb
+++ b/test/looker/test_dynamic_client_agent.rb
@@ -1,7 +1,7 @@
 ############################################################################################
 # The MIT License (MIT)
 #
-# Copyright (c) 2018 Looker Data Sciences, Inc.
+# Copyright (c) 2022 Looker Data Sciences, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- added `nix` support
- updated copyright notices in code license comments
- default to API 4.0 instead of API 3.1