### PR TITLE
allow Faraday 2

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
-  s.add_dependency 'faraday', ['>= 1.2', '< 2.0']
+  s.add_dependency 'faraday', ['>= 1.2', '< 3.0']
   s.add_development_dependency 'ci_reporter_minitest', '~> 1.0'
 end


### PR DESCRIPTION
Allow 2.x Faraday version as it is fully compatible.

As reported in Faraday project repository, there's some breaking changes in the API, but none of them are affecting this gem, at least from my tests, please, allow this PR to execute the workflow and see the result.

This could enable people to upgrade their applications to Faraday 2.x

https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20