### PR TITLE
fix: for 'Insecure usage of ruby gemfile. Missing lockfile'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ out
 .bundle
 .config
 .yardoc
-Gemfile.lock
 Gemfile.optional.lock
 InstalledFiles
 _yardoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     looker-sdk (0.1.2)
-      faraday (>= 1.2, < 2.0)
+      faraday (>= 1.2, < 3.0)
       sawyer (~> 0.8)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,82 @@
+PATH
+  remote: .
+  specs:
+    looker-sdk (0.1.2)
+      faraday (>= 1.2, < 2.0)
+      sawyer (~> 0.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    awesome_print (1.6.1)
+    builder (3.2.4)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_minitest (1.0.0)
+      ci_reporter (~> 2.0)
+      minitest (~> 5.0)
+    faraday (1.10.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
+    metaclass (0.0.4)
+    minitest (5.9.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.15.0)
+    multipart-post (2.2.3)
+    netrc (0.7.9)
+    public_suffix (4.0.7)
+    rack (1.6.4)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    rake (10.5.0)
+    redcarpet (3.1.2)
+    ruby2_keywords (0.0.5)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  awesome_print (~> 1.6.1)
+  ci_reporter_minitest (~> 1.0)
+  looker-sdk!
+  minitest (= 5.9.1)
+  mocha (= 1.1.0)
+  netrc (~> 0.7.7)
+  rack (= 1.6.4)
+  rack-test (= 0.6.2)
+  rake (< 11.0)
+  redcarpet (~> 3.1.2)
+  simplecov (~> 0.7.1)
+
+BUNDLED WITH
+   2.3.26


### PR DESCRIPTION
Received an autoscan notification for "Vulnerability: Insecure usage of ruby gemfile. Missing lockfile." from a fork of this repo. Getting ahead of this one. 