### PR TITLE
Error doc handling

### DIFF
--- a/examples/errors.rb
+++ b/examples/errors.rb
@@ -29,3 +29,19 @@ begin
 rescue LookerSDK::Error => e
   puts e
 end
+
+puts "\n\n"
+
+begin
+  puts sdk.connection("foo").inspect
+rescue LookerSDK::Error => e
+  puts e
+end
+
+puts "\n\n"
+
+begin
+  puts sdk.run_look(1,"foo").inspect
+rescue LookerSDK::Error => e
+  puts e
+end

--- a/examples/errors.rb
+++ b/examples/errors.rb
@@ -1,0 +1,31 @@
+############################################################################################
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 Looker Data Sciences, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+############################################################################################
+
+require './sdk_setup'
+
+begin
+  puts sdk.validate_theme({}).inspect
+rescue LookerSDK::Error => e
+  puts e
+end

--- a/lib/looker-sdk/error.rb
+++ b/lib/looker-sdk/error.rb
@@ -76,6 +76,40 @@ module LookerSDK
       response_message
     end
 
+    # Error Doc URL
+    #
+    # @return [String]
+    def error_doc_url(documentation_url)
+      return nil unless documentation_url
+      regexp = Regexp.new("https://(?<redirector>docs\.looker\.com\|cloud\.google\.com/looker/docs)/r/err/(?<api_version>.*)/(?<status_code>\\d{3})(?<api_path>.*)", Regexp::IGNORECASE)
+      match_data = regexp.match documentation_url
+      return nil unless match_data
+
+      key = "#{match_data[:status_code]}#{match_data[:api_path].gsub(/\/:([^\/]+)/,"/{\\1}")}"
+      error_doc = error_docs[key] || error_docs[match_data[:status_code]]
+      return nil unless error_doc
+
+      return "https://marketplace-api.looker.com/errorcodes/#{error_doc[:url]}"
+    end
+
+    def error_docs
+      @error_docs ||=
+        begin
+          sawyer_options = {
+            :links_parser => Sawyer::LinkParsers::Simple.new,
+            :serializer  => LookerSDK::Client::Serializer.new(JSON),
+            :faraday => Faraday.new
+          }
+
+          agent = Sawyer::Agent.new("https://marketplace-api.looker.com", sawyer_options) do |http|
+            http.headers[:accept] = 'application/json'
+            #http.headers[:user_agent] = conn_hash[:user_agent]
+          end
+          response = agent.call(:get,"/errorcodes/index.json")
+          response.data || []
+        end
+    end
+
     # Returns most appropriate error for 401 HTTP status code
     # @private
     def self.error_for_401(headers)
@@ -142,11 +176,14 @@ module LookerSDK
     def response_error_summary
       return nil unless data.is_a?(Hash) && !Array(data[:errors]).empty?
 
+      data[:errors].each do |e|
+        edu = error_doc_url(e[:documentation_url])
+        e[:error_doc_url] = edu if edu
+      end
       summary = "\nError summary:\n"
       summary << data[:errors].map do |hash|
         hash.map { |k,v| "  #{k}: #{v}" }
       end.join("\n")
-      summary << "\n"
 
       summary
     end
@@ -160,7 +197,8 @@ module LookerSDK
       message << "#{response_message}" unless response_message.nil?
       message << "#{response_error}" unless response_error.nil?
       message << "#{response_error_summary}" unless response_error_summary.nil?
-      message << " // See: #{documentation_url}" unless documentation_url.nil?
+      message << "\n // See: #{documentation_url}" unless documentation_url.nil?
+      message << "\n // And: #{error_doc_url(documentation_url)}" unless error_doc_url(documentation_url).nil?
       message
     end
 

--- a/lib/looker-sdk/error.rb
+++ b/lib/looker-sdk/error.rb
@@ -146,6 +146,7 @@ module LookerSDK
       summary << data[:errors].map do |hash|
         hash.map { |k,v| "  #{k}: #{v}" }
       end.join("\n")
+      summary << "\n"
 
       summary
     end


### PR DESCRIPTION
```
$ ruby errors.rb                                                                                              [47/5305]
POST https://localhost:20000/api/4.0/themes/validate: 422 - Validation Failed                                                                                                        
Error summary:                                                                            
  field: name                        
  code: missing_field                   
  message: 'name' is required.        
  documentation_url: https://cloud.google.com/looker/docs/r/err/4.0/422/post/themes/validate
  error_doc_url: https://marketplace-api.looker.com/errorcodes/422.md                     
  field: name                                                                             
  code: invalid                                                                           
  message: 'name' must be only alphanumeric characters and underscores                    
  documentation_url: https://cloud.google.com/looker/docs/r/err/4.0/422/post/themes/validate
  error_doc_url: https://marketplace-api.looker.com/errorcodes/422.md                                                                                                                
 // See: https://cloud.google.com/looker/docs/r/err/4.0/422/post/themes/validate
 // And: https://marketplace-api.looker.com/errorcodes/422.md


GET https://localhost:20000/api/4.0/connections/foo: 404 - Not found
 // See: https://cloud.google.com/looker/docs/r/err/4.0/404/get/connections/:connection_name
 // And: https://marketplace-api.looker.com/errorcodes/connection_404.md


GET https://localhost:20000/api/4.0/looks/1/run/foo: 422 - Validation Failed
Error summary:
  field: result_format
  code: invalid
  message: Invalid result format: "foo"
  documentation_url: https://cloud.google.com/looker/docs/r/err/4.0/422/get/looks/:look_id/run/:result_format
  error_doc_url: https://marketplace-api.looker.com/errorcodes/422.md
 // See: https://cloud.google.com/looker/docs/r/err/4.0/422/get/looks/:look_id/run/:result_format
 // And: https://marketplace-api.looker.com/errorcodes/422.md
```