### PR TITLE
fix faraday version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    looker-sdk (0.1.3)
-      faraday (>= 1.2, < 3.0)
+    looker-sdk (0.1.4)
+      faraday (~> 1.10)
       sawyer (~> 0.8)
 
 GEM
@@ -65,12 +65,12 @@ GEM
     simplecov-html (0.7.1)
 
 PLATFORMS
+  arm64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
   awesome_print (~> 1.6.1)
   ci_reporter_minitest (~> 1.0)
-  faraday (~> 1.10)
   looker-sdk!
   minitest (= 5.9.1)
   mocha (= 1.1.0)

--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
-  s.add_dependency 'faraday', ['>= 1.2', '< 3.0']
+  s.add_dependency 'faraday', '~> 1.10'
   s.add_development_dependency 'ci_reporter_minitest', '~> 1.0'
-  s.add_development_dependency 'faraday', '~> 1.10'
 end


### PR DESCRIPTION

Hi, I am using [gzr](https://github.com/looker-open-source/gzr), but when I install the latest looker-sdk-ruby version v0.1.4 together, I get the following problem.

```
gems/looker-sdk-0.1.4/lib/looker-sdk/client.rb:476:in `merge_content_type_if_body': uninitialized constant Faraday::UploadIO (NameError )
```

This is probably due to a compatibility error caused by using the faraday v2 series when installing the gem, since faraday's dependencies are written twice, in `add_dependency` and `add_deveploment_dependency`. I fixed it to use the v.1.10 series in `add_dependency`.

In fact, you may want to modify the code to support the faraday v2 series. However, users who try to use gzr by just running `gem install gazer` will not be able to use the command because of this problem, so I think it is better to incorporate this temporary fix.
