### PR TITLE
add test/reports directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ lib/bundler/man
 pkg
 rdoc
 spec/reports
+test/reports
 test/tmp
 test/version_tmp
 tmp


### PR DESCRIPTION
Added the directory of test reports generated by `bundle exec rake test` to .gitignore.