### PR TITLE
Update some dependencies

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: remove mock .netrc
         if: ${{ always() }}
         run: |
-          rm test/fixtures/.netrc
+          rm -f test/fixtures/.netrc
 
       - name: Upload ts unit test results
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *~
 *.sass-cache
 *.iml
-
+.ruby-version
 
 # OS or Editor folders
 .DS_Store
@@ -55,3 +55,6 @@ tmp
 
 # credentials for testing
 .netrc
+
+# test output
+/test/reports/**

--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,15 @@ group :development do
 end
 
 group :development, :test do
-  gem 'rake', '< 11.0'
+  gem 'rake', '~> 13.0.3'
 end
 
 group :test do
   # gem 'json', '~> 1.7', :platforms => [:jruby] look TODO needed?
-  gem 'minitest',         '5.9.1'
-  gem 'mocha',            '1.1.0'
-  gem 'rack',             '1.6.4'
-  gem 'rack-test',        '0.6.2'
+  gem 'minitest', '~> 5.11.0'
+  gem 'mocha', '~> 1.1.0'
+  gem 'rack', '~> 2.2.7'
+  gem 'rack-test', '~> 1'
   gem 'netrc', '~> 0.7.7'
   gem 'simplecov', '~> 0.7.1', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    looker-sdk (0.1.3)
+    looker-sdk (0.1.4)
       faraday (>= 1.2, < 3.0)
       sawyer (~> 0.8)
 
@@ -42,17 +42,17 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     metaclass (0.0.4)
-    minitest (5.9.1)
+    minitest (5.11.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.15.0)
     multipart-post (2.3.0)
     netrc (0.7.9)
     public_suffix (5.0.1)
-    rack (1.6.4)
-    rack-test (0.6.2)
-      rack (>= 1.0)
-    rake (10.5.0)
+    rack (2.2.7)
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (13.0.6)
     redcarpet (3.1.2)
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
@@ -65,6 +65,7 @@ GEM
     simplecov-html (0.7.1)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -72,12 +73,12 @@ DEPENDENCIES
   ci_reporter_minitest (~> 1.0)
   faraday (~> 1.10)
   looker-sdk!
-  minitest (= 5.9.1)
-  mocha (= 1.1.0)
+  minitest (~> 5.11.0)
+  mocha (~> 1.1.0)
   netrc (~> 0.7.7)
-  rack (= 1.6.4)
-  rack-test (= 0.6.2)
-  rake (< 11.0)
+  rack (~> 2.2.7)
+  rack-test (~> 1)
+  rake (~> 13.0.3)
   redcarpet (~> 3.1.2)
   simplecov (~> 0.7.1)
 

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -476,7 +476,7 @@ module LookerSDK
 
     def merge_content_type_if_body(body, options = {})
       if body
-        type = Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0') ? Faraday::UploadIO: Faraday::FilePart
+        type = Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0') ? Faraday::UploadIO : Faraday::FilePart
 
         if body.kind_of?(type)
           length = File.new(body.local_path).size.to_s

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -420,7 +420,11 @@ module LookerSDK
 
     class Serializer < Sawyer::Serializer
       def encode(data)
-        data.kind_of?(Faraday::UploadIO) ? data : super
+        if Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0')
+          data.kind_of?(Faraday::UploadIO) ? data : super
+        else
+          data.kind_of?(Faraday::FilePart) ? data : super
+        end
       end
 
       # slight modification to the base class' decode_hash_value function to
@@ -472,7 +476,9 @@ module LookerSDK
 
     def merge_content_type_if_body(body, options = {})
       if body
-        if body.kind_of?(Faraday::UploadIO)
+        type = Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0') ? Faraday::UploadIO: Faraday::FilePart
+
+        if body.kind_of?(type)
           length = File.new(body.local_path).size.to_s
           headers = {:content_type => body.content_type, :content_length => length}.merge(options[:headers] || {})
         else

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -223,7 +223,12 @@ class LookerDynamicClientTest < MiniTest::Spec
     it "post with file upload" do
       verify(response, :post, '/api/3.0/users', {first_name:'Joe', last_name:'User'}, {}, "application/vnd.BOGUS3+json") do |sdk|
         name = File.join(File.dirname(__FILE__), 'user.json')
-        sdk.create_user(Faraday::UploadIO.new(name, "application/vnd.BOGUS3+json"))
+        if Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0')
+          sdk.create_user(Faraday::UploadIO.new(name, "application/vnd.BOGUS3+json"))
+        else
+          sdk.create_user(Faraday::FilePart.new(name, "application/vnd.BOGUS3+json"))
+        end
+
       end
     end
 


### PR DESCRIPTION
The main impetus for this PR is to update the very outdated rack dep, which keeps registering critical issues in our vulnerability scanners.

While I was at it, I updated a few others. Would be nice to update rack-test to 2.1 and mocha as well, but they require more extensive changes.

Also fixed a CI issue and faraday 1.x/2.x compat issue while I was at it.

<img width="577" alt="image" src="https://github.com/looker-open-source/looker-sdk-ruby/assets/275524/44c2514e-b08b-47fc-bb77-551ed548b3e3">
