### PR TITLE
Fix for faraday-multipart disabled

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         ruby-version: [2.7.7]
         looker: ${{ fromJson(needs.setup.outputs.matrix_json) }}
+        use_faraday_multipart: ['true', 'false']
 
     steps:
       - name: Cancel Previous Runs
@@ -98,6 +99,8 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test --trace
+        env:
+          USE_FARADAY_MULTIPART: ${{ matrix.use_faraday_multipart }}
 
       - name: remove mock .netrc
         if: ${{ always() }}

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -423,7 +423,7 @@ module LookerSDK
         if Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0')
           data.kind_of?(Faraday::UploadIO) ? data : super
         else
-          data.kind_of?(Faraday::FilePart) ? data : super
+          defined?(Faraday::FilePart) && data.kind_of?(Faraday::FilePart) ? data : super
         end
       end
 
@@ -476,9 +476,11 @@ module LookerSDK
 
     def merge_content_type_if_body(body, options = {})
       if body
-        type = Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0') ? Faraday::UploadIO : Faraday::FilePart
+        multipart = Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0') ?
+          body.kind_of?(Faraday::UploadIO) :
+          defined?(Faraday::FilePart) && body.kind_of?(Faraday::FilePart)
 
-        if body.kind_of?(type)
+        if multipart
           length = File.new(body.local_path).size.to_s
           headers = {:content_type => body.content_type, :content_length => length}.merge(options[:headers] || {})
         else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -42,7 +42,7 @@ require 'mocha/mini_test'
 require "rack/test"
 require "rack/request"
 require "faraday/rack"
-require "faraday/multipart"
+# require "faraday/multipart"
 
 def fixture_path
   File.expand_path("../fixtures", __FILE__)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -42,7 +42,7 @@ require 'mocha/mini_test'
 require "rack/test"
 require "rack/request"
 require "faraday/rack"
-# require "faraday/multipart"
+require "faraday/multipart" if ENV['USE_FARADAY_MULTIPART'] == 'true'
 
 def fixture_path
   File.expand_path("../fixtures", __FILE__)

--- a/test/looker/test_dynamic_client.rb
+++ b/test/looker/test_dynamic_client.rb
@@ -226,9 +226,9 @@ class LookerDynamicClientTest < MiniTest::Spec
         if Gem.loaded_specs['faraday'].version < Gem::Version.new('2.0')
           sdk.create_user(Faraday::UploadIO.new(name, "application/vnd.BOGUS3+json"))
         else
+          skip unless defined?(Faraday::FilePart)
           sdk.create_user(Faraday::FilePart.new(name, "application/vnd.BOGUS3+json"))
         end
-
       end
     end
 


### PR DESCRIPTION
Since faraday 2.0, faraday-multipart is a optional feature.
It is up to an user to decide whether to use faraday-multipart.

This PR fixes `NameError` when user don't use faraday-multipart.
```
NameError: uninitialized constant Faraday::FilePart
```