### PR TITLE
fix(deps): Add faraday-multipart as actual dep

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'jruby-openssl' if s.platform == :jruby
   s.add_dependency 'sawyer', '~> 0.8'
   s.add_dependency 'faraday', ['>= 1.2', '< 3.0']
+  s.add_dependency 'faraday-multipart', '~> 1.0'
   s.add_development_dependency 'ci_reporter_minitest', '~> 1.0'
   s.add_development_dependency 'faraday', '~> 2.7'
   s.add_development_dependency 'faraday-rack', '~> 2'
-  s.add_development_dependency 'faraday-multipart', '~> 1.0'
 end


### PR DESCRIPTION
We ran into an issue recently where we changed our code to not load faraday-multipart on startup and hit an issue with the looker-sdk complaining it could not find `Faraday::Multipart`. Since that code is used at runtime, that should be an actual dependency and not a dev dep only.