### PR TITLE
chore(build): Only include things that are necessary in gem

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
   s.requirements = 'Looker version 4.0 or later'  # informational
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test}/*`.split("\n")
+  s.files         = Dir["lib/**/*", "*.md"]
+  s.test_files    = Dir["test/**/*"]
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby


### PR DESCRIPTION
The main impetus for this change is that because the Gemfile.lock was being included in the published gem, it's causing our security scanners to go nuts with all the old dependencies listed in it.  This is nicer from a cleaniness pov as well.

Gem contents before:
<img width="173" alt="image" src="https://github.com/looker-open-source/looker-sdk-ruby/assets/275524/13d3483d-adbb-4842-8bfa-e76eb99afe80">

After:
<img width="187" alt="image" src="https://github.com/looker-open-source/looker-sdk-ruby/assets/275524/78c76c0a-dac5-4a3c-8428-96689baf34d9">


