### PR TITLE
chore(build): Only include things that are necessary in gem

### DIFF
--- a/looker-sdk.gemspec
+++ b/looker-sdk.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
   s.requirements = 'Looker version 4.0 or later'  # informational
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test}/*`.split("\n")
+  s.files         = Dir["lib/**/*", "*.md"]
+  s.test_files    = Dir["test/**/*"]
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = %w(lib)
   s.add_dependency 'jruby-openssl' if s.platform == :jruby


### PR DESCRIPTION
From @mscrivo 

The main impetus for this change is that because the Gemfile.lock was being included in the published gem, it's causing our security scanners to go nuts with all the old dependencies listed in it. This is nicer from a cleaniness pov as well.

Gem contents before:
![image](https://github.com/looker-open-source/looker-sdk-ruby/assets/10760721/e85e7b2a-3879-4c67-b449-7fcbd9f24b05)


After:
![image](https://github.com/looker-open-source/looker-sdk-ruby/assets/10760721/46aacaa5-b872-4dfa-8776-a9400a5faf21)
