### PR TITLE
Add ruby2_keywords for ruby 3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 group :development, :test do
   gem 'rake', '~> 13.2.1'
+  gem 'ruby2_keywords'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,8 @@ DEPENDENCIES
   rack-test (~> 2)
   rake (~> 13.2.1)
   redcarpet (~> 3.6.0)
+  ruby2_keywords
   simplecov (~> 0.22.0)
 
 BUNDLED WITH
-   2.4.14
+   2.4.22

--- a/lib/looker-sdk.rb
+++ b/lib/looker-sdk.rb
@@ -50,6 +50,7 @@ end
 
 #require 'rack'
 #require 'rack/mock_response'
+require 'ruby2_keywords'
 
 require 'looker-sdk/client'
 require 'looker-sdk/default'
@@ -74,7 +75,7 @@ module LookerSDK
 
   private
 
-    def method_missing(method_name, *args, &block)
+    ruby2_keywords def method_missing(method_name, *args, &block)
       return super unless client.respond_to?(method_name)
       client.send(method_name, *args, &block)
     end

--- a/lib/looker-sdk/client.rb
+++ b/lib/looker-sdk/client.rb
@@ -30,6 +30,7 @@ require 'looker-sdk/authentication'
 require 'looker-sdk/rate_limit'
 require 'looker-sdk/client/dynamic'
 require 'looker-sdk/error'
+require 'ruby2_keywords'
 
 module LookerSDK
 
@@ -293,7 +294,7 @@ module LookerSDK
     # LOOKER_SILENT is set to true.
     #
     # @return [nil]
-    def looker_warn(*message)
+    ruby2_keywords def looker_warn(*message)
       unless ENV['LOOKER_SILENT']
         warn message
       end

--- a/lib/looker-sdk/client/dynamic.rb
+++ b/lib/looker-sdk/client/dynamic.rb
@@ -22,6 +22,8 @@
 # THE SOFTWARE.
 ############################################################################################
 
+require 'ruby2_keywords'
+
 module LookerSDK
   class Client
 
@@ -97,12 +99,12 @@ module LookerSDK
       # Callers can explicitly 'invoke' remote methods or let 'method_missing' do the trick.
       # If nothing else, this gives clients a way to deal with potential conflicts between remote method
       # names and names of methods on client itself.
-      def invoke(method_name, *args, &block)
+      ruby2_keywords def invoke(method_name, *args, &block)
         entry = find_entry(method_name) || raise(NameError, "undefined remote method '#{method_name}'")
         invoke_remote(entry, method_name, *args, &block)
       end
 
-      def method_missing(method_name, *args, &block)
+      ruby2_keywords def method_missing(method_name, *args, &block)
         entry = find_entry(method_name) || (return super)
         invoke_remote(entry, method_name, *args, &block)
       end
@@ -117,7 +119,7 @@ module LookerSDK
         operations && operations[method_name.to_sym] if dynamic
       end
 
-      def invoke_remote(entry, method_name, *args, &block)
+      ruby2_keywords def invoke_remote(entry, method_name, *args, &block)
         args = (args || []).dup
         route = entry[:route].to_s.dup
         params = (entry[:info][:parameters] || []).select {|param| param[:in] == 'path'}

--- a/lib/looker-sdk/default.rb
+++ b/lib/looker-sdk/default.rb
@@ -31,7 +31,7 @@ module LookerSDK
   module Default
 
     # Default API endpoint look TODO update this as needed
-    API_ENDPOINT = "https://localhost:19999/api/3.0/".freeze
+    API_ENDPOINT = "https://localhost:19999/api/4.0/".freeze
 
     # Default User Agent header string
     USER_AGENT   = "Looker Ruby Gem #{LookerSDK::VERSION}".freeze


### PR DESCRIPTION
To deal with keyword argument incompatibilities between Ruby 3 and earlier versions (see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), we can use the [ruby2_keywords gem](https://github.com/ruby/ruby2_keywords/blob/master/README.md) to decorate some of the functions that currently use the `def method(*args)` pattern that breaks in 3.0
