### PR TITLE
fix: allow tests to run against remote server

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -94,6 +94,7 @@ def setup_sdk
     else
       c.netrc = true
       c.netrc_file =  File.join(fixture_path, '.netrc')
+      c.api_endpoint = "#{base_url}/api/#{api_version}"
     end
   end
 end

--- a/test/looker/test_client.rb
+++ b/test/looker/test_client.rb
@@ -57,6 +57,7 @@ describe LookerSDK::Client do
     opts.merge!({
       :netrc => true,
       :netrc_file => File.join(fixture_path, '.netrc'),
+      :api_endpoint => "#{base_url}/api/#{api_version}",
       :connection_options => {:ssl => {:verify => false}},
     })
 
@@ -156,12 +157,14 @@ describe LookerSDK::Client do
 
       describe "with .netrc"  do
         it "can read .netrc files" do
-          skip unless File.exist?(File.join(fixture_path, '.netrc'))
+          netrc_file = File.expand_path('../../../examples/.netrc', __FILE__)
+          skip unless File.exist?(netrc_file)
           LookerSDK.reset!
+          File.chmod(0600, netrc_file)
           client = LookerSDK::Client.new(
             :lazy_swagger => true,
             :netrc => true,
-            :netrc_file => File.join(fixture_path, '.netrc'),
+            :netrc_file => netrc_file,
           )
           client.client_id.wont_be_nil
           client.client_secret.wont_be_nil

--- a/test/looker/test_inline_query.rb
+++ b/test/looker/test_inline_query.rb
@@ -57,6 +57,7 @@ describe LookerSDK::Client do
     opts.merge!({
       :netrc => true,
       :netrc_file => File.join(fixture_path, '.netrc'),
+      :api_endpoint => "#{base_url}/api/#{api_version}",
       :connection_options => {:ssl => {:verify => false}},
     })
 


### PR DESCRIPTION
This fixes the tests so that you can actually use a remote server and `LOOKERSDK_BASE_URL` to run the tests